### PR TITLE
bump version of AWSSDK.MobileAnalytics to 3.5.0.2 and update version …

### DIFF
--- a/src/AWSSDK.MobileAnalytics.MobileAnalyticsManager.csproj
+++ b/src/AWSSDK.MobileAnalytics.MobileAnalyticsManager.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;net35</TargetFrameworks>
     <DefineConstants>$(DefineConstants);BCL</DefineConstants>
-    <Version>3.5.0.0-beta</Version>
+    <Version>3.5.0.0</Version>
     <PackageId>AWSSDK.MobileAnalytics.MobileAnalyticsManager</PackageId>
     <Title>AWSSDK - Amazon Cognito Sync Manager</Title>
     <Product>AWSSDK.MobileAnalytics.MobileAnalyticsManager</Product>
@@ -46,7 +46,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="AWSSDK.MobileAnalytics" Version="3.5.0-beta" />
+    <PackageReference Include="AWSSDK.MobileAnalytics" Version="3.5.0.2" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.97.0" />
   </ItemGroup>
 


### PR DESCRIPTION
…of package to 3.5.0.0 due to release of AWS SDK for .NET 3.5

*Issue #, if available:*

*Description of changes:*
Update package version and dependency versions in line with AWS SDK for .NET v3.5 release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
