### PR TITLE
Use PackageIcon instead of PackageIconUrl

### DIFF
--- a/src/AWSSDK.MobileAnalytics.MobileAnalyticsManager.csproj
+++ b/src/AWSSDK.MobileAnalytics.MobileAnalyticsManager.csproj
@@ -12,8 +12,7 @@
     <PackageTags>&gt;AWS;Amazon;cloud;CognitoSync;CognitoSyncManager;aws-sdk-v3</PackageTags>
     <PackageProjectUrl>https://github.com/aws/aws-mobile-analytics-manager-net</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <!-- Replace with PackageIcon when Visual Studio supports it. -->
-    <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <RepositoryUrl>https://github.com/aws/aws-mobile-analytics-manager-net/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
*Description of changes:*
Use PackageIcon instead of PackageIconUrl which is being deprecated: https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5048

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
