### PR TITLE
Fix build failure occurring while using .NET 5 CLI

### DIFF
--- a/src/AWSSDK.MobileAnalytics.MobileAnalyticsManager.csproj
+++ b/src/AWSSDK.MobileAnalytics.MobileAnalyticsManager.csproj
@@ -39,6 +39,9 @@
 
       <!-- workaround per https://github.com/Microsoft/msbuild/issues/1333 -->
       <FrameworkPathOverride>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
+
+      <!-- workaround per https://github.com/dotnet/msbuild/issues/5985 -->
+      <AutomaticallyUseReferenceAssemblyPackages Condition=" '$(TargetFramework)' == 'net35' ">false</AutomaticallyUseReferenceAssemblyPackages>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use workaround suggested [here](https://github.com/dotnet/msbuild/issues/5985) unblock release pipeline 

`dotnet build .\src\AWSSDK.MobileAnalytics.MobileAnalyticsManager.csproj` succeeds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
