### PR TITLE
chore: Update threshold for days-before-stale to 5 days and days-before-close to 2 days for stale issue GitHub action.

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -14,8 +14,8 @@ jobs:
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category
-        ancient-issue-message: We have noticed this issue has not recieved attention in 1 year. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
-        stale-issue-message: This issue has not recieved a response in 1 week. If you want to keep this issue open, please just leave a comment below and auto-close will be canceled.
+        ancient-issue-message: We have noticed this issue has not received attention in 1 year. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
+        stale-issue-message: This issue has not received a response in 5 days. If you want to keep this issue open, please just leave a comment below and auto-close will be canceled.
 
         # These labels are required
         stale-issue-label: closing-soon
@@ -29,8 +29,8 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-stale: 7
-        days-before-close: 4
+        days-before-stale: 5
+        days-before-close: 2
         days-before-ancient: 365
 
         # If you don't want to mark a issue as being ancient based on a


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update threshold for `days-before-stale` to 5 days and `days-before-close` to 2 days for stale issue GitHub action.

Stale issues requiring response from user are taking long time to automatically close by stale issue GitHub action. OSDS team had decided to set the threshold for days-before-stale to 5 days and days-before-close to 2 days, this needs to be updated in the .NET/PowerShell/HLL repos.

___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
