### PR TITLE
chore: Update stale issues GitHub action to use the latest version.

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v3
+    - uses: aws-actions/stale-issue-cleanup@main
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
chore: Update stale issues GitHub action to use the latest version.

*NOTE:* Pointing to explicit tag or commit enables to avoid any breaking changes, specially when the repository is maintained by 3rd party. Since `aws-actions` is maintained by us, to avoid changing the GitHub action reference every time new version is released, it was discussed to set it to `main`.

___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
